### PR TITLE
Use SEEK_END instead of 2

### DIFF
--- a/cgstream.c
+++ b/cgstream.c
@@ -250,7 +250,7 @@ strid_t glk_stream_open_file(fileref_t *fref, glui32 fmode,
     }
     
     if (fmode == filemode_WriteAppend) {
-        fseek(fl, 0, 2); /* ...to the end. */
+        fseek(fl, 0, SEEK_END); /* ...to the end. */
     }
 
     str = gli_new_stream(strtype_File, 


### PR DESCRIPTION
I'm not aware of any systems on which SEEK_END doesn't have the value 2, but nothing precludes such an implementation.